### PR TITLE
Add sanity check for javafx.version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,11 +145,9 @@ jobs:
           platform: ${{ steps.platform.outputs.platform }}
       - name: Setup JavaFX (Windows)
         if: runner.os == 'Windows'
-        uses: carlosperate/download-file-action@v1
-        with:
-          file-url: 'https://download2.gluonhq.com/openjfx/${{ steps.sdk.outputs.sdk_versionpath }}/openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip'
-          file-name: 'openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip'
-          location: 'D:'
+        run: |
+          Import-Module BitsTransfer; Start-BitsTransfer https://download2.gluonhq.com/openjfx/${{ steps.sdk.outputs.sdk_versionpath }}/openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip D:\openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip
+          Expand-Archive -Force D:\openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip D:\
         env:
           sdk_version: ${{ steps.sdk.outputs.sdk_version }}
       - name: Test Gradle (Linux)
@@ -241,7 +239,7 @@ jobs:
       - name: Setup JavaFX (Windows)
         if: runner.os == 'Windows'
         run: |
-          bitsadmin /Transfer DownloadJavaFX https://download2.gluonhq.com/openjfx/${{ steps.jmod.outputs.jmod_versionpath }}/openjfx-${{ env.jmod_version }}_windows-x64_bin-jmods.zip ${{ runner.temp }}\openjfx-${{ env.jmod_version }}_windows-x64_bin-jmods.zip
+          Import-Module BitsTransfer; Start-BitsTransfer https://download2.gluonhq.com/openjfx/${{ steps.jmod.outputs.jmod_versionpath }}/openjfx-${{ env.jmod_version }}_windows-x64_bin-jmods.zip ${{ runner.temp }}\openjfx-${{ env.jmod_version }}_windows-x64_bin-jmods.zip
           Expand-Archive -Force ${{ runner.temp }}\openjfx-${{ env.jmod_version }}_windows-x64_bin-jmods.zip D:\
         env:
           jmod_version: ${{ steps.jmod.outputs.jmod_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,8 +146,9 @@ jobs:
       - name: Setup JavaFX (Windows)
         if: runner.os == 'Windows'
         run: |
-          bitsadmin /Transfer DownloadJavaFX https://download2.gluonhq.com/openjfx/${{ steps.sdk.outputs.sdk_versionpath }}/openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip D:\openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip
-          Expand-Archive -Force D:\openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip D:\
+          wget -P /tmp https://download2.gluonhq.com/openjfx/${{ steps.sdk.outputs.sdk_versionpath }}/openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip
+          unzip /tmp/openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip -d D:
+        shell: bash
         env:
           sdk_version: ${{ steps.sdk.outputs.sdk_version }}
       - name: Test Gradle (Linux)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,25 +161,28 @@ jobs:
           vncserver :90 -localhost -nolisten tcp
           cd ${{ matrix.type }}/gradle/hellofx
           chmod +x gradlew
-          ./gradlew run -Psdk=${{ env.JAVAFX_HOME }}
+          ./gradlew run -Psdk=${{ env.JAVAFX_HOME }} -Pjavafx_version=${{ env.sdk_version }}
           vncserver -kill :90
         env:
           JAVAFX_HOME: ${{ steps.platform.outputs.javafx }}
+          sdk_version: ${{ steps.sdk.outputs.sdk_version }}
       - name: Test Gradle (MacOS)
         if: runner.os == 'macOS'
         run: |
           cd ${{ matrix.type }}/gradle/hellofx
           chmod +x gradlew
-          ./gradlew run -Psdk=${{ env.JAVAFX_HOME }}
+          ./gradlew run -Psdk=${{ env.JAVAFX_HOME }} -Pjavafx_version=${{ env.sdk_version }}
         env:
           JAVAFX_HOME: ${{ steps.platform.outputs.javafx }}
+          sdk_version: ${{ steps.sdk.outputs.sdk_version }}
       - name: Test Gradle (Windows)
         if: runner.os == 'windows'
         run: |
           cd ${{ matrix.type }}/gradle/hellofx
-          .\gradlew run -Psdk="${{ env.JAVAFX_HOME }}"
+          .\gradlew run -Psdk="${{ env.JAVAFX_HOME }}" -Pjavafx_version="${{ env.sdk_version }}"
         env:
           JAVAFX_HOME: ${{ steps.platform.outputs.javafx }}
+          sdk_version: ${{ steps.sdk.outputs.sdk_version }}
   jmod:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -251,11 +254,12 @@ jobs:
           --add-modules javafx.fxml,javafx.controls,hellofx \
           --output ${{ env.RUNTIME }} \
           --strip-debug --compress 2 --no-header-files --no-man-pages
-          ${{ env.JAVA_RUNTIME }} -m hellofx/org.openjfx.MainApp
+          ${{ env.JAVA_RUNTIME }} -Dsettings.javafx.version=${{ env.jmod_version }} -m hellofx/org.openjfx.MainApp
         env:
           RUNTIME: ${{ steps.platform.outputs.runtime }}
           JAVA_RUNTIME: ${{ steps.platform.outputs.java_runtime }}
           JMOD_HOME: ${{ steps.platform.outputs.jmod_home }}
+          jmod_version: ${{ steps.jmod.outputs.jmod_version }}
 
       - name: Test JMODS (Windows)
         if: runner.os == 'Windows'
@@ -269,11 +273,12 @@ jobs:
           --add-modules javafx.fxml,javafx.controls,hellofx `
           --output ${{ env.RUNTIME }} `
           --strip-debug --compress 2 --no-header-files --no-man-pages
-          ${{ env.JAVA_RUNTIME }} -m hellofx/org.openjfx.MainApp
+          ${{ env.JAVA_RUNTIME }} -Dsettings.javafx.version=${{ env.jmod_version }} -m hellofx/org.openjfx.MainApp
         env:
           RUNTIME: ${{ steps.platform.outputs.runtime }}
           JAVA_RUNTIME: ${{ steps.platform.outputs.java_runtime }}
-          JMOD_HOME: ${{ steps.platform.outputs.jmod_home }}   
+          JMOD_HOME: ${{ steps.platform.outputs.jmod_home }}
+          jmod_version: ${{ steps.jmod.outputs.jmod_version }}
 
       - name: Test JMODS (Linux)
         if: runner.os == 'Linux'
@@ -292,9 +297,10 @@ jobs:
           echo 123456 | vncpasswd -f > /home/runner/.vnc/passwd
           chmod -v 600 /home/runner/.vnc/passwd
           vncserver :90 -localhost -nolisten tcp
-          ${{ env.JAVA_RUNTIME }} -m hellofx/org.openjfx.MainApp
+          ${{ env.JAVA_RUNTIME }} -Dsettings.javafx.version=${{ env.jmod_version }} -m hellofx/org.openjfx.MainApp
           vncserver -kill :90
         env:
           RUNTIME: ${{ steps.platform.outputs.runtime }}
           JAVA_RUNTIME: ${{ steps.platform.outputs.java_runtime }}
           JMOD_HOME: ${{ steps.platform.outputs.jmod_home }}
+          jmod_version: ${{ steps.jmod.outputs.jmod_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,7 +273,7 @@ jobs:
           --add-modules javafx.fxml,javafx.controls,hellofx `
           --output ${{ env.RUNTIME }} `
           --strip-debug --compress 2 --no-header-files --no-man-pages
-          ${{ env.JAVA_RUNTIME }} -Dsettings.javafx.version="${{ env.jmod_version }}" -m hellofx/org.openjfx.MainApp
+          ${{ env.JAVA_RUNTIME }} --% -Dsettings.javafx.version="${{ env.jmod_version }}" -m hellofx/org.openjfx.MainApp
         env:
           RUNTIME: ${{ steps.platform.outputs.runtime }}
           JAVA_RUNTIME: ${{ steps.platform.outputs.java_runtime }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,10 +145,11 @@ jobs:
           platform: ${{ steps.platform.outputs.platform }}
       - name: Setup JavaFX (Windows)
         if: runner.os == 'Windows'
-        run: |
-          wget -P /tmp https://download2.gluonhq.com/openjfx/${{ steps.sdk.outputs.sdk_versionpath }}/openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip
-          unzip /tmp/openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip -d D:
-        shell: bash
+        uses: carlosperate/download-file-action@v1
+        with:
+          file-url: 'https://download2.gluonhq.com/openjfx/${{ steps.sdk.outputs.sdk_versionpath }}/openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip'
+          file-name: 'openjfx-${{ env.sdk_version }}_windows-x64_bin-sdk.zip'
+          location: 'D:'
         env:
           sdk_version: ${{ steps.sdk.outputs.sdk_version }}
       - name: Test Gradle (Linux)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,7 +273,7 @@ jobs:
           --add-modules javafx.fxml,javafx.controls,hellofx `
           --output ${{ env.RUNTIME }} `
           --strip-debug --compress 2 --no-header-files --no-man-pages
-          ${{ env.JAVA_RUNTIME }} -Dsettings.javafx.version=${{ env.jmod_version }} -m hellofx/org.openjfx.MainApp
+          ${{ env.JAVA_RUNTIME }} -Dsettings.javafx.version="${{ env.jmod_version }}" -m hellofx/org.openjfx.MainApp
         env:
           RUNTIME: ${{ steps.platform.outputs.runtime }}
           JAVA_RUNTIME: ${{ steps.platform.outputs.java_runtime }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,8 @@ jobs:
           vncserver :90 -localhost -nolisten tcp
           mvn -q versions:set-property -Dproperty=staging.repo.url -DnewVersion=${{ env.staging_url }} -DgenerateBackupPoms=false -f ${{ matrix.type }}/maven/hellofx
           mvn -q versions:set-property -Dproperty=javafx.version -DnewVersion=${{ env.maven_version }} -DgenerateBackupPoms=false -f ${{ matrix.type }}/maven/hellofx
-          mvn clean compile -f ${{ matrix.type }}/maven/hellofx
-          mvn javafx:run -f ${{ matrix.type }}/maven/hellofx
+          mvn -q clean compile -f ${{ matrix.type }}/maven/hellofx
+          mvn -q javafx:run -f ${{ matrix.type }}/maven/hellofx
           vncserver -kill :90
         env:
           staging_url: ${{ steps.staging.outputs.staging_url }}
@@ -49,8 +49,8 @@ jobs:
         run: |
           mvn -q versions:set-property -Dproperty=staging.repo.url -DnewVersion=${{ env.staging_url }} -DgenerateBackupPoms=false -f ${{ matrix.type }}/maven/hellofx
           mvn -q versions:set-property -Dproperty=javafx.version -DnewVersion=${{ env.maven_version }} -DgenerateBackupPoms=false -f ${{ matrix.type }}/maven/hellofx
-          mvn clean compile -f ${{ matrix.type }}/maven/hellofx
-          mvn javafx:run -f ${{ matrix.type }}/maven/hellofx
+          mvn -q clean compile -f ${{ matrix.type }}/maven/hellofx
+          mvn -q javafx:run -f ${{ matrix.type }}/maven/hellofx
         env:
           staging_url: ${{ steps.staging.outputs.staging_url }}
           maven_version: ${{ steps.staging.outputs.maven_version }}
@@ -59,8 +59,8 @@ jobs:
         run: |
           mvn -q versions:set-property -Dproperty="staging.repo.url" -DnewVersion="${{ env.staging_url }}" -DgenerateBackupPoms=false -f ${{ matrix.type }}/maven/hellofx
           mvn -q versions:set-property -Dproperty="javafx.version" -DnewVersion="${{ env.maven_version }}" -DgenerateBackupPoms=false -f ${{ matrix.type }}/maven/hellofx
-          mvn clean compile -f ${{ matrix.type }}/maven/hellofx
-          mvn javafx:run -f ${{ matrix.type }}/maven/hellofx
+          mvn -q clean compile -f ${{ matrix.type }}/maven/hellofx
+          mvn -q javafx:run -f ${{ matrix.type }}/maven/hellofx
         env:
           staging_url: ${{ steps.staging.outputs.staging_url }}
           maven_version: ${{ steps.staging.outputs.maven_version }}

--- a/modular/gradle/hellofx/build.gradle
+++ b/modular/gradle/hellofx/build.gradle
@@ -20,4 +20,8 @@ javafx {
     modules = [ 'javafx.controls', 'javafx.fxml' ]
 }
 
+run {
+    systemProperty "settings.javafx.version", project.hasProperty('javafx_version') ? project.property('javafx_version') : ''
+}
+
 mainClassName = "org.openjfx.MainApp"

--- a/modular/gradle/hellofx/src/main/java/org/openjfx/MainApp.java
+++ b/modular/gradle/hellofx/src/main/java/org/openjfx/MainApp.java
@@ -12,6 +12,16 @@ public class MainApp extends Application {
 
     @Override
     public void start(Stage stage) throws Exception {
+        String javaVersion = System.getProperty("java.version");
+        String javafxVersion = System.getProperty("javafx.version");
+
+        // Test JavaFX version
+        String javaFXSettingVersion = System.getProperty("settings.javafx.version");
+        if (!javaFXSettingVersion.equals(javafxVersion)) {
+            System.out.println("Mismatch of JavaFX version occurred. Expected: '" + javaFXSettingVersion + "' but found: '" + javafxVersion + "'.");
+            System.exit(1);
+        }
+
         System.out.println("Starting Application...");
         Parent root = FXMLLoader.load(getClass().getResource("scene.fxml"));
         
@@ -22,8 +32,6 @@ public class MainApp extends Application {
         stage.setScene(scene);
         stage.show();
 
-        String javaVersion = System.getProperty("java.version");
-        String javafxVersion = System.getProperty("javafx.version");
         System.out.println("Hello, JavaFX " + javafxVersion + ", running on Java " + javaVersion + ".");
 
         if (System.getProperty("javafx.platform") == null) {

--- a/modular/gradle/hellofx/src/main/java/org/openjfx/MainApp.java
+++ b/modular/gradle/hellofx/src/main/java/org/openjfx/MainApp.java
@@ -16,7 +16,7 @@ public class MainApp extends Application {
         String javafxVersion = System.getProperty("javafx.version");
 
         // Test JavaFX version
-        String javaFXSettingVersion = System.getProperty("settings.javafx.version");
+        String javaFXSettingVersion = trimEAVersion(System.getProperty("settings.javafx.version"));
         if (!javaFXSettingVersion.equals(javafxVersion)) {
             System.out.println("Mismatch of JavaFX version occurred. Expected: '" + javaFXSettingVersion + "' but found: '" + javafxVersion + "'.");
             System.exit(1);
@@ -46,6 +46,13 @@ public class MainApp extends Application {
 
     public static void main(String[] args) {
         launch(args);
+    }
+
+    private String trimEAVersion(String property) {
+        if (property.contains("+")) {
+            property = property.substring(0, property.indexOf("+"));
+        }
+        return property;
     }
 
 }

--- a/modular/maven/hellofx/pom.xml
+++ b/modular/maven/hellofx/pom.xml
@@ -59,6 +59,9 @@
                     <jlinkImageName>hellofx</jlinkImageName>
                     <launcher>launcher</launcher>
                     <mainClass>hellofx/org.openjfx.MainApp</mainClass>
+                    <options>
+                        <option>-Dsettings.javafx.version=${javafx.version}</option>
+                    </options>
                 </configuration>
             </plugin>
         </plugins>

--- a/modular/maven/hellofx/pom.xml
+++ b/modular/maven/hellofx/pom.xml
@@ -12,8 +12,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>11</maven.compiler.release>
-        <javafx.version>17</javafx.version>
-        <javafx.maven.plugin.version>0.0.6</javafx.maven.plugin.version>
+        <javafx.version>17.0.2</javafx.version>
+        <javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
         <staging.repo.url>https://oss.sonatype.org/service/local/repositories/orgopenjfx-1148/content</staging.repo.url>
     </properties>
 

--- a/modular/maven/hellofx/src/main/java/org/openjfx/MainApp.java
+++ b/modular/maven/hellofx/src/main/java/org/openjfx/MainApp.java
@@ -12,6 +12,16 @@ public class MainApp extends Application {
 
     @Override
     public void start(Stage stage) throws Exception {
+        String javaVersion = System.getProperty("java.version");
+        String javafxVersion = System.getProperty("javafx.version");
+
+        // Test JavaFX version
+        String javaFXSettingVersion = System.getProperty("settings.javafx.version");
+        if (!javaFXSettingVersion.equals(javafxVersion)) {
+            System.out.println("Mismatch of JavaFX version occurred. Expected: '" + javaFXSettingVersion + "' but found: '" + javafxVersion + "'.");
+            System.exit(1);
+        }
+
         System.out.println("Starting Application...");
         Parent root = FXMLLoader.load(getClass().getResource("scene.fxml"));
         
@@ -22,8 +32,6 @@ public class MainApp extends Application {
         stage.setScene(scene);
         stage.show();
 
-        String javaVersion = System.getProperty("java.version");
-        String javafxVersion = System.getProperty("javafx.version");
         System.out.println("Hello, JavaFX " + javafxVersion + ", running on Java " + javaVersion + ".");
 
         if (System.getProperty("javafx.platform") == null) {

--- a/modular/maven/hellofx/src/main/java/org/openjfx/MainApp.java
+++ b/modular/maven/hellofx/src/main/java/org/openjfx/MainApp.java
@@ -16,7 +16,7 @@ public class MainApp extends Application {
         String javafxVersion = System.getProperty("javafx.version");
 
         // Test JavaFX version
-        String javaFXSettingVersion = System.getProperty("settings.javafx.version");
+        String javaFXSettingVersion = trimEAVersion(System.getProperty("settings.javafx.version"));
         if (!javaFXSettingVersion.equals(javafxVersion)) {
             System.out.println("Mismatch of JavaFX version occurred. Expected: '" + javaFXSettingVersion + "' but found: '" + javafxVersion + "'.");
             System.exit(1);
@@ -46,6 +46,13 @@ public class MainApp extends Application {
 
     public static void main(String[] args) {
         launch(args);
+    }
+
+    private String trimEAVersion(String property) {
+        if (property.contains("+")) {
+            property = property.substring(0, property.indexOf("+"));
+        }
+        return property;
     }
 
 }

--- a/non-modular/gradle/hellofx/build.gradle
+++ b/non-modular/gradle/hellofx/build.gradle
@@ -19,4 +19,8 @@ javafx {
     modules = [ 'javafx.controls' ]
 }
 
+run {
+    systemProperty "settings.javafx.version", project.hasProperty('javafx_version') ? project.property('javafx_version') : ''
+}
+
 mainClassName = 'org.openjfx.Launcher'

--- a/non-modular/gradle/hellofx/src/main/java/org/openjfx/HelloFX.java
+++ b/non-modular/gradle/hellofx/src/main/java/org/openjfx/HelloFX.java
@@ -12,9 +12,17 @@ public class HelloFX extends Application {
 
     @Override
     public void start(Stage stage) {
-        System.out.println("Starting Application...");
         String javaVersion = System.getProperty("java.version");
         String javafxVersion = System.getProperty("javafx.version");
+
+        // Test JavaFX version
+        String javaFXSettingVersion = System.getProperty("settings.javafx.version");
+        if (!javaFXSettingVersion.equals(javafxVersion)) {
+            System.out.println("Mismatch of JavaFX version occurred. Expected: '" + javaFXSettingVersion + "' but found: '" + javafxVersion + "'.");
+            System.exit(1);
+        }
+
+        System.out.println("Starting Application...");
         Label l = new Label("Hello, JavaFX " + javafxVersion + ", running on Java " + javaVersion + ".");
         Scene scene = new Scene(new StackPane(l), 640, 480);
         stage.setScene(scene);

--- a/non-modular/gradle/hellofx/src/main/java/org/openjfx/HelloFX.java
+++ b/non-modular/gradle/hellofx/src/main/java/org/openjfx/HelloFX.java
@@ -16,7 +16,7 @@ public class HelloFX extends Application {
         String javafxVersion = System.getProperty("javafx.version");
 
         // Test JavaFX version
-        String javaFXSettingVersion = System.getProperty("settings.javafx.version");
+        String javaFXSettingVersion = trimEAVersion(System.getProperty("settings.javafx.version"));
         if (!javaFXSettingVersion.equals(javafxVersion)) {
             System.out.println("Mismatch of JavaFX version occurred. Expected: '" + javaFXSettingVersion + "' but found: '" + javafxVersion + "'.");
             System.exit(1);
@@ -41,6 +41,13 @@ public class HelloFX extends Application {
 
     public static void main(String[] args) {
         launch();
+    }
+
+    private String trimEAVersion(String property) {
+        if (property.contains("+")) {
+            property = property.substring(0, property.indexOf("+"));
+        }
+        return property;
     }
 
 }

--- a/non-modular/maven/hellofx/pom.xml
+++ b/non-modular/maven/hellofx/pom.xml
@@ -10,8 +10,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>11</maven.compiler.release>
-        <javafx.version>17</javafx.version>
-        <javafx.maven.plugin.version>0.0.6</javafx.maven.plugin.version>
+        <javafx.version>17.0.2</javafx.version>
+        <javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
         <staging.repo.url>https://oss.sonatype.org/service/local/repositories/orgopenjfx-1148/content</staging.repo.url>
     </properties>
 

--- a/non-modular/maven/hellofx/pom.xml
+++ b/non-modular/maven/hellofx/pom.xml
@@ -31,7 +31,7 @@
       <version>${javafx.version}</version>
     </dependency>
   </dependencies>
-  
+
   <build>
       <plugins>
           <plugin>
@@ -48,6 +48,9 @@
               <version>${javafx.maven.plugin.version}</version>
               <configuration>
                   <mainClass>org.openjfx.Launcher</mainClass>
+                  <options>
+                      <option>-Dsettings.javafx.version=${javafx.version}</option>
+                  </options>
               </configuration>
           </plugin>
     </plugins>

--- a/non-modular/maven/hellofx/src/main/java/org/openjfx/HelloFX.java
+++ b/non-modular/maven/hellofx/src/main/java/org/openjfx/HelloFX.java
@@ -12,9 +12,17 @@ public class HelloFX extends Application {
 
     @Override
     public void start(Stage stage) {
-        System.out.println("Starting Application...");
         String javaVersion = System.getProperty("java.version");
         String javafxVersion = System.getProperty("javafx.version");
+
+        // Test JavaFX version
+        String javaFXSettingVersion = System.getProperty("settings.javafx.version");
+        if (!javaFXSettingVersion.equals(javafxVersion)) {
+            System.out.println("Mismatch of JavaFX version occurred. Expected: '" + javaFXSettingVersion + "' but found: '" + javafxVersion + "'.");
+            System.exit(1);
+        }
+
+        System.out.println("Starting Application...");
         Label l = new Label("Hello, JavaFX " + javafxVersion + ", running on Java " + javaVersion + ".");
         Scene scene = new Scene(new StackPane(l), 640, 480);
         stage.setScene(scene);

--- a/non-modular/maven/hellofx/src/main/java/org/openjfx/HelloFX.java
+++ b/non-modular/maven/hellofx/src/main/java/org/openjfx/HelloFX.java
@@ -16,7 +16,7 @@ public class HelloFX extends Application {
         String javafxVersion = System.getProperty("javafx.version");
 
         // Test JavaFX version
-        String javaFXSettingVersion = System.getProperty("settings.javafx.version");
+        String javaFXSettingVersion = trimEAVersion(System.getProperty("settings.javafx.version"));
         if (!javaFXSettingVersion.equals(javafxVersion)) {
             System.out.println("Mismatch of JavaFX version occurred. Expected: '" + javaFXSettingVersion + "' but found: '" + javafxVersion + "'.");
             System.exit(1);
@@ -41,6 +41,13 @@ public class HelloFX extends Application {
 
     public static void main(String[] args) {
         launch();
+    }
+
+    private String trimEAVersion(String property) {
+        if (property.contains("+")) {
+            property = property.substring(0, property.indexOf("+"));
+        }
+        return property;
     }
 
 }

--- a/settings.properties
+++ b/settings.properties
@@ -1,4 +1,4 @@
 staging_url=https://oss.sonatype.org/content/repositories/orgopenjfx-1165
-maven_version=17.0.2
-sdk_version=17.0.2
-jmod_version=17.0.2
+maven_version=18-ea+10
+sdk_version=18-ea+10
+jmod_version=18-ea+10

--- a/settings.properties
+++ b/settings.properties
@@ -1,4 +1,4 @@
 staging_url=https://oss.sonatype.org/content/repositories/orgopenjfx-1165
-maven_version=17.0.2
-sdk_version=17.0.2
-jmod_version=17.0.2
+maven_version=17
+sdk_version=17
+jmod_version=17

--- a/settings.properties
+++ b/settings.properties
@@ -1,4 +1,4 @@
 staging_url=https://oss.sonatype.org/content/repositories/orgopenjfx-1165
-maven_version=18-ea+10
-sdk_version=18-ea+10
-jmod_version=18-ea+10
+maven_version=17.0.2
+sdk_version=17.0.2
+jmod_version=17.0.2

--- a/settings.properties
+++ b/settings.properties
@@ -1,4 +1,4 @@
 staging_url=https://oss.sonatype.org/content/repositories/orgopenjfx-1165
-maven_version=17
-sdk_version=17
-jmod_version=17
+maven_version=17.0.2
+sdk_version=17.0.2
+jmod_version=17.0.2


### PR DESCRIPTION
Also, has the following updates:

* Use `Import-Module BitsTransfer; Start-BitsTransfer` to download sdk and jmods in Windows
* Update default javafx-version to `17.0.2` as `17` fails for modular maven projects
* Use `--quiet` mode to execute maven commands

For tests check: https://github.com/abhinayagarwal/openjfx-smoke-tests/actions