### PR TITLE
Add depdenabot configruation

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+  - package-ecosystem: "gradle"
+    directories:
+      - "modular/gradle/hellofx"
+      - "non-modular/gradle/hellofx"
+    schedule:
+      interval: weekly
+      day: sunday
+  - package-ecosystem: "maven"
+    directories:
+      - "modular/maven/hellofx"
+      - "non-modular/maven/hellofx"
+    schedule:
+      interval: weekly
+      day: sunday


### PR DESCRIPTION
I like automatic updates. This PR adds automatic updates for both github actions and gradle/maven.

See https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories for some more inspiration.